### PR TITLE
added Delve Walls and Paths

### DIFF
--- a/IconsBuilder.cs
+++ b/IconsBuilder.cs
@@ -106,6 +106,7 @@ namespace IconsBuilder
         public override void OnLoad()
         {
             Graphics.InitImage("sprites.png");
+            Graphics.InitImage("Icons.png");
         }
 
         public override void EntityIgnored(Entity Entity)
@@ -251,6 +252,10 @@ namespace IconsBuilder
                 return new MiscIcon(entity, GameController, Settings);
 
             if (entity.Path.Contains("Metadata/Terrain/Leagues/Delve/Objects/EncounterControlObjects/AzuriteEncounterController"))
+                return new MiscIcon(entity, GameController, Settings);
+
+            //delve paths
+            if (entity.Path.EndsWith("Metadata/Terrain/Leagues/Delve/Objects/DelveLight"))
                 return new MiscIcon(entity, GameController, Settings);
 
             if (entity.Type == EntityType.LegionMonolith) return new MiscIcon(entity, GameController, Settings);

--- a/IconsBuilderSettings.cs
+++ b/IconsBuilderSettings.cs
@@ -29,6 +29,10 @@ namespace IconsBuilder
         public ToggleNode ShowSmallChest { get; set; } = new ToggleNode(false);
         [Menu("Size small chests icon")]
         public RangeNode<int> SizeSmallChestIcon { get; set; } = new RangeNode<int>(10, 1, 50);
+        [Menu("Show delve paths")]
+        public ToggleNode ShowDelvePaths { get; set; } = new ToggleNode(false);
+        [Menu("Size delve paths")]
+        public RangeNode<int> SizeDelvePaths { get; set; } = new RangeNode<int>(10, 1, 50);
         [Menu("Size misc icon")]
         public RangeNode<int> SizeMiscIcon { get; set; } = new RangeNode<int>(10, 1, 50);
         [Menu("Size shrine icon")]

--- a/MiscIcon.cs
+++ b/MiscIcon.cs
@@ -35,7 +35,13 @@ namespace IconsBuilder
                 Text = RenderName;
                 Priority = IconPriority.VeryHigh;
                 if (entity.GetComponent<MinimapIcon>().Name.Equals("DelveRobot", StringComparison.Ordinal)) Text = "Follow Me";
-
+                //Delve Walls
+                if (entity.Path.Contains("Metadata/Terrain/Leagues/Delve/Objects/DelveWall"))
+                {
+                    MainTexture.Size = settings.SizeChestIcon;
+                    MainTexture.UV = SpriteHelper.GetUV(MapIconsIndex.Entrance);
+                    Show = () => entity.IsAlive;
+                }
                 return;
             }
 
@@ -110,6 +116,13 @@ namespace IconsBuilder
                     Show = () => entity.IsValid && entity.GetComponent<Transitionable>().Flag1 < 3;
                     MainTexture.UV = SpriteHelper.GetUV(MapIconsIndex.PartyLeader);
                 }
+            }
+            //delve paths
+            if (entity.Path.Contains("Objects/DelveLight") && entity.HasComponent<Preload>())
+            {
+                MainTexture.Size = settings.SizeDelvePaths;
+                MainTexture.UV = SpriteHelper.GetUV(MapIconsIndex.LootFilterSmallYellowCircle);
+                Show = () => entity.IsAlive && settings.ShowDelvePaths;
             }
         }
     }


### PR DESCRIPTION
In conjunction with another pull request for Minimap Icons plugin.
Adds Delve Walls as orange portal and Delve Paths as custom-sized yellow dots (can change size or turn off in plugin settings).
![delveWallsPahts](https://user-images.githubusercontent.com/51941670/88370353-8e0b8a00-cd9a-11ea-9b6d-433ec40302a2.png)
